### PR TITLE
Update contrast for better readability

### DIFF
--- a/os-app/_shared/common/ui-style.css
+++ b/os-app/_shared/common/ui-style.css
@@ -1,8 +1,8 @@
 :root {
-	--OLSKCommonBackground: #00b046;
+	--OLSKCommonBackground: #006627;
 	--OLSKDecorBackgroundDeep: #0b5823;
 	--OLSKDecorBackgroundDeepEdge: #00cc00;
-	--OLSKCommonForeground: #B0Fe5D;
+	--OLSKCommonForeground: #ffffff;
 	--OLSKDecorBackgroundDark: #008833;
 	--OLSKDecorForegroundLight: #8ed04a;
 }

--- a/os-app/_shared/common/ui-style.css
+++ b/os-app/_shared/common/ui-style.css
@@ -1,10 +1,10 @@
 :root {
-	--OLSKCommonBackground: #006627;
-	--OLSKDecorBackgroundDeep: #0b5823;
-	--OLSKDecorBackgroundDeepEdge: #00cc00;
-	--OLSKCommonForeground: #ffffff;
-	--OLSKDecorBackgroundDark: #008833;
-	--OLSKDecorForegroundLight: #8ed04a;
+	--OLSKCommonBackground: #007d32;
+	--OLSKDecorBackgroundDeep: #0e401d;
+	--OLSKDecorBackgroundDeepEdge: #309d30;
+	--OLSKCommonForeground: #d0fba2;
+	--OLSKDecorBackgroundDark: #006426;
+	--OLSKDecorForegroundLight: #478c00;
 }
 
 html, body, .OLSKDecorCapped {

--- a/os-app/open-glance/ui-style.css
+++ b/os-app/open-glance/ui-style.css
@@ -44,7 +44,7 @@
 }
 
 .EASGlanceList {
-	background: #006627;
+	background: var(--OLSKDecorBackgroundDark);
 }
 
 .EASGlanceListSort {

--- a/os-app/open-glance/ui-style.css
+++ b/os-app/open-glance/ui-style.css
@@ -44,7 +44,7 @@
 }
 
 .EASGlanceList {
-	background: #009538;
+	background: #006627;
 }
 
 .EASGlanceListSort {


### PR DESCRIPTION
The site's contrast ratio is really low, making it hard to read

![Screenshot from 2022-12-13 11-16-13](https://user-images.githubusercontent.com/8533113/207219449-d0169c62-55b0-4fb9-8c45-7e0497b75223.png)

![Screenshot from 2022-12-13 11-16-22](https://user-images.githubusercontent.com/8533113/207219464-cee80622-020a-4eb1-9349-22731bd88bcd.png)

![Screenshot from 2022-12-13 11-14-41](https://user-images.githubusercontent.com/8533113/207219526-2c98ac90-0b9f-4825-85ef-edbfb32a6265.png)

I've updated the colors in a way that I believe maintains the stylistic intention, while making it much more readable:

![Screenshot from 2022-12-13 11-26-39](https://user-images.githubusercontent.com/8533113/207219593-9b0c1611-12a4-44aa-9481-344393ae9ebf.png)
![Screenshot from 2022-12-13 11-26-20](https://user-images.githubusercontent.com/8533113/207219599-56521540-4764-4482-9d3c-3864a6269f75.png)
![Screenshot from 2022-12-13 11-23-05](https://user-images.githubusercontent.com/8533113/207219603-dd64e82d-8c75-4e45-bf8e-c11c39061cef.png)
![Screenshot from 2022-12-13 11-22-39](https://user-images.githubusercontent.com/8533113/207219607-0cfd2715-7541-4c1a-8fdd-b672b75ac675.png)
